### PR TITLE
Refactor and simplify

### DIFF
--- a/v3/geohex.go
+++ b/v3/geohex.go
@@ -12,7 +12,9 @@ const MaxLevel = 20
 var (
 	hChars = []byte{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 	hIndex = make(map[byte]int, len(hChars))
-	hK     = math.Tan(math.Pi / 6.0)
+
+	// nScaleFactor is used to transform hexagons into non-regular which have two square angles by shrinking them in N dimension
+	nScaleFactor = math.Tan(math.Pi / 6.0)
 )
 
 const (

--- a/v3/geohex.go
+++ b/v3/geohex.go
@@ -13,21 +13,20 @@ var (
 	hChars = []byte{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 	hIndex = make(map[byte]int, len(hChars))
 	hK     = math.Tan(math.Pi / 6.0)
-	hD2R   = math.Pi / 180.0
 )
 
 const (
+	hD2R  = math.Pi / 180.0
+	hR2D  = 180 / math.Pi
 	hBase = 20037508.34
-	hEr   = 6371007.2
+	pio4  = math.Pi / 4
 )
 
 // A zoom is a helper for level dimensions
 type Zoom struct {
-	level int
-	size  float64
-	scale float64
-	w     float64
-	h     float64
+	level  int
+	size   float64
+	factor float64
 }
 
 // Cached zooms lookup
@@ -60,7 +59,7 @@ func (ll *LL) Point() *Point {
 func init() {
 	for level := 0; level <= MaxLevel; level++ {
 		size := hBase / math.Pow(3, float64(level+3))
-		zooms[level] = &Zoom{level: level, size: size, scale: size / hEr, w: 6 * size, h: 6 * size * hK}
+		zooms[level] = &Zoom{level: level, size: size, factor: 6 * size}
 	}
 
 	for i, b := range hChars {

--- a/v3/geohex.go
+++ b/v3/geohex.go
@@ -16,9 +16,17 @@ var (
 )
 
 const (
+	// Constant math stuff
 	deg2rad = math.Pi / 360.0
 	rad2deg = 360 / math.Pi
 	pio4    = math.Pi / 4
+)
+
+var (
+	// Precalculated math stuff
+	pow3f         [MaxLevel + 4]float64
+	pow3i         [MaxLevel + 4]int
+	halfCeilPow3f [MaxLevel + 4]float64
 )
 
 // A zoom is a helper for level dimensions
@@ -28,7 +36,7 @@ type Zoom struct {
 }
 
 // Cached zooms lookup
-var zooms = make(map[int]*Zoom, 20)
+var zooms = make(map[int]*Zoom, MaxLevel)
 
 // LL is a lat/lon tuple
 type LL struct {
@@ -53,11 +61,16 @@ func (ll *LL) Point() *Point {
 	return &Point{E: e, N: n}
 }
 
-// Init zooms
+// init precalculates frequently used things
 func init() {
+	for i := 0; i <= MaxLevel+3; i++ {
+		pow3f[i] = math.Pow(3, float64(i))
+		halfCeilPow3f[i] = pow3f[i] / 2
+		pow3i[i] = int(math.Pow(3, float64(i)))
+	}
+
 	for level := 0; level <= MaxLevel; level++ {
-		size := 1 / math.Pow(3, float64(level+3))
-		zooms[level] = &Zoom{level: level, factor: 6 * size}
+		zooms[level] = &Zoom{level: level, factor: 6 / pow3f[level+3]}
 	}
 
 	for i, b := range hChars {

--- a/v3/geohex.go
+++ b/v3/geohex.go
@@ -16,16 +16,14 @@ var (
 )
 
 const (
-	hD2R  = math.Pi / 180.0
-	hR2D  = 180 / math.Pi
-	hBase = 20037508.34
-	pio4  = math.Pi / 4
+	deg2rad = math.Pi / 360.0
+	rad2deg = 360 / math.Pi
+	pio4    = math.Pi / 4
 )
 
 // A zoom is a helper for level dimensions
 type Zoom struct {
 	level  int
-	size   float64
 	factor float64
 }
 
@@ -39,7 +37,7 @@ type LL struct {
 
 // NewLL creates a new normalised LL
 func NewLL(lat, lon float64) *LL {
-	if lon < -180 {
+	if lon <= -180 {
 		lon += 360
 	} else if lon > 180 {
 		lon -= 360
@@ -49,8 +47,8 @@ func NewLL(lat, lon float64) *LL {
 
 // Point generates a grid point from a lat/lon
 func (ll *LL) Point() *Point {
-	e := ll.Lon * hBase / 180.0
-	n := math.Log(math.Tan((90+ll.Lat)*hD2R/2)) / math.Pi * hBase
+	e := ll.Lon / 180.0
+	n := math.Log(math.Tan(ll.Lat*deg2rad+pio4)) / math.Pi
 
 	return &Point{E: e, N: n}
 }
@@ -58,8 +56,8 @@ func (ll *LL) Point() *Point {
 // Init zooms
 func init() {
 	for level := 0; level <= MaxLevel; level++ {
-		size := hBase / math.Pow(3, float64(level+3))
-		zooms[level] = &Zoom{level: level, size: size, factor: 6 * size}
+		size := 1 / math.Pow(3, float64(level+3))
+		zooms[level] = &Zoom{level: level, factor: 6 * size}
 	}
 
 	for i, b := range hChars {

--- a/v3/geohex_test.go
+++ b/v3/geohex_test.go
@@ -84,9 +84,7 @@ var _ = Describe("Zoom", func() {
 		subject = zooms[7]
 		Expect(subject.level).To(Equal(7))
 		Expect(subject.size).To(BeNumerically("~", 339.337, 0.001))
-		Expect(subject.scale).To(BeNumerically("~", 0.000053, 0.000001))
-		Expect(subject.w).To(BeNumerically("~", 2036.022, 0.001))
-		Expect(subject.h).To(BeNumerically("~", 1175.498, 0.001))
+		Expect(subject.factor).To(BeNumerically("~", 2036.022, 0.001))
 	})
 })
 
@@ -106,5 +104,4 @@ var _ = Describe("LL", func() {
 		pt := NewLL(66.68, -87.98).Point()
 		Expect(pt).To(BeAssignableToTypeOf(&Point{}))
 	})
-
 })

--- a/v3/geohex_test.go
+++ b/v3/geohex_test.go
@@ -83,8 +83,7 @@ var _ = Describe("Zoom", func() {
 	It("should calculate attributes", func() {
 		subject = zooms[7]
 		Expect(subject.level).To(Equal(7))
-		Expect(subject.size).To(BeNumerically("~", 339.337, 0.001))
-		Expect(subject.factor).To(BeNumerically("~", 2036.022, 0.001))
+		Expect(subject.factor).To(BeNumerically("~", 0.0001, 0.00001))
 	})
 })
 

--- a/v3/point.go
+++ b/v3/point.go
@@ -11,7 +11,8 @@ type Point struct {
 
 // Position returns the X/Y grid position of the Point
 func (p *Point) Position(z *Zoom) *Position {
-	x, y := (p.N/hK+p.E)/z.factor, (p.N/hK-p.E)/z.factor
+	x := (p.N/nScaleFactor + p.E) / z.factor
+	y := (p.N/nScaleFactor - p.E) / z.factor
 
 	x0, y0 := math.Floor(x), math.Floor(y)
 	xd, yd := x-x0, y-y0

--- a/v3/point.go
+++ b/v3/point.go
@@ -11,7 +11,8 @@ type Point struct {
 
 // Position returns the X/Y grid position of the Point
 func (p *Point) Position(z *Zoom) *Position {
-	x, y := (p.E+p.N/hK)/z.w, (p.N-hK*p.E)/z.h
+	x, y := (p.N/hK+p.E)/z.factor, (p.N/hK-p.E)/z.factor
+
 	x0, y0 := math.Floor(x), math.Floor(y)
 	xd, yd := x-x0, y-y0
 
@@ -25,4 +26,12 @@ func (p *Point) Position(z *Zoom) *Position {
 	}
 
 	return &pos
+}
+
+// LL returns LL coordinates of this point
+func (p *Point) LL() *LL {
+	lat := (math.Atan(math.Exp(p.N/hBase*180*hD2R)) - pio4) * 2 * hR2D
+	lon := p.E / hBase * 180
+
+	return NewLL(lat, lon)
 }

--- a/v3/point.go
+++ b/v3/point.go
@@ -22,8 +22,10 @@ func (p *Point) Position(z *Zoom) *Position {
 		pos.X, pos.Y = int(x0)+1, int(y0)+1
 	} else if yd < -xd+1 && yd > 2*xd-1 && yd < 0.5*xd+0.5 {
 		pos.X, pos.Y = int(x0), int(y0)
+	} else if xd+yd <= 1 {
+		pos.X, pos.Y = int(x0)+1, int(y0)
 	} else {
-		pos.X, pos.Y = int(math.Floor(x+0.499999)), int(math.Floor(y+0.499999))
+		pos.X, pos.Y = int(x0), int(y0)+1
 	}
 
 	return &pos

--- a/v3/point.go
+++ b/v3/point.go
@@ -30,8 +30,8 @@ func (p *Point) Position(z *Zoom) *Position {
 
 // LL returns LL coordinates of this point
 func (p *Point) LL() *LL {
-	lat := (math.Atan(math.Exp(p.N/hBase*180*hD2R)) - pio4) * 2 * hR2D
-	lon := p.E / hBase * 180
+	lat := (math.Atan(math.Exp(p.N*math.Pi)) - pio4) * rad2deg
+	lon := p.E * 180
 
 	return NewLL(lat, lon)
 }

--- a/v3/point_test.go
+++ b/v3/point_test.go
@@ -14,10 +14,10 @@ var _ = Describe("Point", func() {
 	})
 
 	It("should create points", func() {
-		Expect(p1.E).To(BeNumerically("~", 19919568.3, 0.1))
-		Expect(p1.N).To(BeNumerically("~", -304192.7, 0.1))
-		Expect(p2.E).To(BeNumerically("~", 19244476.4, 0.1))
-		Expect(p2.N).To(BeNumerically("~", 17189491.4, 0.1))
+		Expect(p1.E).To(BeNumerically("~", 0.9941140, 0.1))
+		Expect(p1.N).To(BeNumerically("~", -0.015181, 0.1))
+		Expect(p2.E).To(BeNumerically("~", 0.9604226, 0.1))
+		Expect(p2.N).To(BeNumerically("~", 0.8578657, 0.1))
 	})
 
 	It("should export grid positions", func() {

--- a/v3/point_test.go
+++ b/v3/point_test.go
@@ -31,4 +31,13 @@ var _ = Describe("Point", func() {
 		Expect(pos.Y).To(Equal(2))
 		Expect(pos.z.level).To(Equal(0))
 	})
+
+	It("should return same LL", func() {
+		ll1 := p1.LL()
+		Expect(ll1.Lat).To(BeNumerically("~", -2.731, 0.01))
+		Expect(ll1.Lon).To(BeNumerically("~", 178.940, 0.01))
+		ll2 := p2.LL()
+		Expect(ll2.Lat).To(BeNumerically("~", 82.272, 0.01))
+		Expect(ll2.Lon).To(BeNumerically("~", 172.876, 0.01))
+	})
 })

--- a/v3/position.go
+++ b/v3/position.go
@@ -8,11 +8,12 @@ type Position struct {
 
 // Centroid returns the centroid point of the tile
 func (p *Position) Centroid() *Point {
-	x := float64(p.X)
-	y := float64(p.Y)
-	n := (x + y) * p.z.factor * hK / 2
-	e := n/hK - y*p.z.factor
-	return &Point{E: e, N: n}
+	x, y := float64(p.X), float64(p.Y)
+
+	return &Point{
+		E: p.z.factor * (x - y) / 2,
+		N: p.z.factor * (x + y) * nScaleFactor,
+	}
 }
 
 // LL converts the position into a LL

--- a/v3/position.go
+++ b/v3/position.go
@@ -1,30 +1,21 @@
 package geohex
 
-import "math"
-
 // Position implements a grid tile position
 type Position struct {
 	X, Y int
 	z    *Zoom
 }
 
-// Centroid returns the centroidpoint of the tile
+// Centroid returns the centroid point of the tile
 func (p *Position) Centroid() *Point {
 	x := float64(p.X)
 	y := float64(p.Y)
-	n := (hK*x*p.z.w + y*p.z.h) / 2
-	e := (n - y*p.z.h) / hK
+	n := (x + y) * p.z.factor * hK / 2
+	e := n/hK - y*p.z.factor
 	return &Point{E: e, N: n}
 }
 
 // LL converts the position into a LL
 func (p *Position) LL() *LL {
-	c := p.Centroid()
-	lon := 180.0
-	lat := 180 / math.Pi * (2*math.Atan(math.Exp(c.N/hBase*180*hD2R)) - math.Pi/2)
-	if hBase-c.E >= p.z.size {
-		lon = c.E / hBase * 180
-	}
-
-	return NewLL(lat, lon)
+	return p.Centroid().LL()
 }

--- a/v3/position_test.go
+++ b/v3/position_test.go
@@ -10,7 +10,7 @@ var _ = Describe("Position", func() {
 	It("should generate centroids", func() {
 		pos := &Position{4, -5, zooms[0]}
 		cnt := pos.Centroid()
-		Expect(cnt.E).To(BeNumerically("~", 20037508.3, 0.1))
+		Expect(cnt.E).To(BeNumerically("~", hBase, 0.1))
 		Expect(cnt.N).To(BeNumerically("~", -1285406.8, 0.1))
 	})
 

--- a/v3/position_test.go
+++ b/v3/position_test.go
@@ -10,8 +10,8 @@ var _ = Describe("Position", func() {
 	It("should generate centroids", func() {
 		pos := &Position{4, -5, zooms[0]}
 		cnt := pos.Centroid()
-		Expect(cnt.E).To(BeNumerically("~", hBase, 0.1))
-		Expect(cnt.N).To(BeNumerically("~", -1285406.8, 0.1))
+		Expect(cnt.E).To(BeNumerically("~", 1, 0.1))
+		Expect(cnt.N).To(BeNumerically("~", -0.06415, 0.1))
 	})
 
 })

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -44,12 +44,8 @@ func Encode(lat, lon float64, level int) (_ *Zone, err error) {
 
 	pnt := NewLL(lat, lon).Point() // Point at lat/lon
 	pos := pnt.Position(zoom)      // Tile position
-	cnt := pos.Centroid()          // Centroid of pos
 
 	x, y := float64(pos.X), float64(pos.Y)
-	if hBase-cnt.E < zoom.size {
-		x, y = y, x
-	}
 	base, num, code := 0, 0, make([]byte, level+2)
 
 	for i := 0; i < level+3; i++ {

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -2,7 +2,6 @@ package geohex
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 )
 
@@ -17,13 +16,6 @@ type Zone struct {
 	Code string
 	Pos  *Position
 }
-
-var (
-	// Precalculated math stuff
-	pow3f         [MaxLevel + 3]float64
-	pow3i         [MaxLevel + 3]int
-	halfCeilPow3f [MaxLevel + 3]float64
-)
 
 // String returns the zone code
 func (z *Zone) String() string {
@@ -137,12 +129,4 @@ func Decode(code string) (_ *LL, err error) {
 	}
 
 	return pos.LL(), nil
-}
-
-func init() {
-	for i := 0; i < MaxLevel+3; i++ {
-		pow3f[i] = math.Pow(3, float64(i))
-		halfCeilPow3f[i] = pow3f[i] / 2
-		pow3i[i] = int(math.Pow(3, float64(i)))
-	}
 }

--- a/v3/zone_test.go
+++ b/v3/zone_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Encode", func() {
 var _ = Describe("Decode", func() {
 
 	for _, tc := range testCases {
-		It("should encode from "+tc.code, func() {
+		It("should decode from "+tc.code, func() {
 			exp := NewLL(tc.lat, tc.lon).Point().Position(zooms[tc.level]).LL()
 			act, err := Decode(tc.code)
 			Expect(err).To(BeNil())
@@ -46,6 +46,7 @@ var testCases = []struct {
 	level int
 	code  string
 }{
+	{15, -179, 0, "QU"},
 	{33.35137950146622, 135.6104480957031, 0, "XM"},
 	{-1.150500622870068, -9.233301904296898, 0, "OY"},
 	{-2.7315738409448347, 178.9405262207031, 0, "GI"},


### PR DESCRIPTION
Simplified a lot of logic, removing unneeded calculations.

The only calculation I doubt about is the swap of `x, y = y, x` that was done on the east border of the map, but it's still passing all the tests so I'll assume it's okay.

Ecuador length (`hBase`) was removed as we can project always on a 1x1 square

The `pos.X, pos.Y = int(math.Floor(x+0.499999)), int(math.Floor(y+0.499999))` expression was replaced by a simple if condition, dropping the point on the upper or lower hexagon.

All contract tests are passing as they were before, but internals had to be fixed (because `E, N` coordinates now don't depend on the Earth size or zoom) 